### PR TITLE
Add a function to mark models as decoratable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ public function show(User $user)
 }
 ```
 
+### Decoratable
+
+To mimic the `Decoratable` interface of the parent package, you can call `decoratable`:
+
+```php
+public function register()
+{
+    \Presenters::decorate(User::class);
+    \Presenters::decorate([
+        User::class,
+        ...
+    ]);
+    ...
+}
+```
+
 ## License
 
 Laravel Auto Presenter Mapper is licensed under [The MIT License (MIT)](LICENSE).

--- a/src/AutoPresenterMapper.php
+++ b/src/AutoPresenterMapper.php
@@ -32,7 +32,7 @@ class AutoPresenterMapper
     }
 
     /**
-     * Add a decoratable model (it has no presenter, but its relations can be decorated)
+     * Add a decoratable model (it has no presenter, but its relations can be decorated).
      *
      * @param $class
      */

--- a/src/AutoPresenterMapper.php
+++ b/src/AutoPresenterMapper.php
@@ -32,6 +32,16 @@ class AutoPresenterMapper
     }
 
     /**
+     * Add a decoratable model (it has no presenter, but its relations can be decorated)
+     *
+     * @param $class
+     */
+    public function decorate($class)
+    {
+        $this->map($class, null);
+    }
+
+    /**
      * Remove a presenter mapping.
      *
      * @param string $class

--- a/src/Decorators/MapperDecorator.php
+++ b/src/Decorators/MapperDecorator.php
@@ -89,7 +89,13 @@ class MapperDecorator implements DecoratorInterface
             }
         }
 
-        if (! class_exists($presenter = $this->autoPresenterMapper->getPresenter($subject))) {
+        $presenter = $this->autoPresenterMapper->getPresenter($subject);
+
+        if ($presenter === null) {
+            return $subject;
+        }
+
+        if (! class_exists($presenter)) {
             throw new PresenterNotFoundException($presenter);
         }
 

--- a/tests/AutoPresenterMapperTest.php
+++ b/tests/AutoPresenterMapperTest.php
@@ -2,7 +2,6 @@
 
 namespace RickSelby\Tests;
 
-use Illuminate\Support\Collection;
 use RickSelby\Tests\Stubs\MappedStub;
 use RickSelby\Tests\Stubs\UnmappedStub;
 use RickSelby\Tests\Stubs\MappedStubPresenter;

--- a/tests/AutoPresenterMapperTest.php
+++ b/tests/AutoPresenterMapperTest.php
@@ -19,55 +19,47 @@ class AutoPresenterMapperTest extends AbstractTestCase
         $this->autoPresenterMapper = $app->make(AutoPresenterMapper::class);
     }
 
-    public function testMappingsIsCollection()
-    {
-        $this->assertInstanceOf(Collection::class, $this->autoPresenterMapper->getMappings());
-    }
-
-    public function testSetMapping()
+    public function testSetMappingHasMapping()
     {
         $this->setMapping();
+        $this->assertTrue($this->autoPresenterMapper->hasPresenter(new MappedStub()));
+    }
 
-        $mappings = $this->autoPresenterMapper->getMappings();
+    public function testSetMappingDoesNotSetForUnmapped()
+    {
+        $this->setMapping();
+        $this->assertFalse($this->autoPresenterMapper->hasPresenter(new UnmappedStub()));
+    }
 
-        $this->assertEquals(1, $mappings->count());
-        $this->assertEquals(MappedStub::class, $mappings->keys()->first());
-        $this->assertEquals(MappedStubPresenter::class, $mappings->first());
+    public function testSetMappingReturnsCorrectClass()
+    {
+        $this->setMapping();
+        $this->assertEquals(MappedStubPresenter::class, $this->autoPresenterMapper->getPresenter(new MappedStub()));
     }
 
     public function testSetMappingAsArray()
     {
         $this->setMappingAsArray();
-
-        $mappings = $this->autoPresenterMapper->getMappings();
-
-        $this->assertEquals(1, $mappings->count());
-        $this->assertEquals(MappedStub::class, $mappings->keys()->first());
-        $this->assertEquals(MappedStubPresenter::class, $mappings->first());
+        $this->assertTrue($this->autoPresenterMapper->hasPresenter(new MappedStub()));
     }
 
     public function testRemoveMapping()
     {
         $this->setMapping();
         $this->autoPresenterMapper->remove(MappedStub::class);
-
-        $mappings = $this->autoPresenterMapper->getMappings();
-
-        $this->assertEquals(0, $mappings->count());
+        $this->assertFalse($this->autoPresenterMapper->hasPresenter(new MappedStub()));
     }
 
-    public function testHasPresenter()
+    public function testDecorating()
     {
-        $this->setMapping();
-        $this->assertTrue($this->autoPresenterMapper->hasPresenter($this->getMappedStub()));
-        $this->assertFalse($this->autoPresenterMapper->hasPresenter($this->getUnmappedStub()));
+        $this->setDecorating();
+        $this->assertTrue($this->autoPresenterMapper->hasPresenter(new MappedStub()));
     }
 
-    public function testGetPresenter()
+    public function testDecoratingReturnsNoClass()
     {
-        $this->setMapping();
-        $this->assertEquals(MappedStubPresenter::class, $this->autoPresenterMapper->getPresenter($this->getMappedStub()));
-        $this->assertNull($this->autoPresenterMapper->getPresenter($this->getUnmappedStub()));
+        $this->setDecorating();
+        $this->assertNull($this->autoPresenterMapper->getPresenter(new MappedStub()));
     }
 
     protected function getMappedStub()
@@ -88,5 +80,10 @@ class AutoPresenterMapperTest extends AbstractTestCase
     protected function setMappingAsArray()
     {
         $this->autoPresenterMapper->map([MappedStub::class => MappedStubPresenter::class]);
+    }
+
+    protected function setDecorating()
+    {
+        $this->autoPresenterMapper->decorate(MappedStub::class);
     }
 }

--- a/tests/Decorators/MapperDecoratorTest.php
+++ b/tests/Decorators/MapperDecoratorTest.php
@@ -2,8 +2,6 @@
 
 namespace RickSelby\Tests\Decorators;
 
-use Mockery;
-use RickSelby\Tests\AutoPresenterMapperTest;
 use RickSelby\Tests\Stubs\MappedStub;
 use RickSelby\Tests\Stubs\UnmappedStub;
 use Illuminate\Contracts\Container\Container;


### PR DESCRIPTION
(so their relations are parsed, but they themselves aren't touched)